### PR TITLE
[DOX-5340] Reduce API calls for packet update

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -671,8 +671,6 @@ module DocusignRest
       ios = create_file_ios(options[:files])
       file_params = create_file_params(ios)
 
-      debugger
-
       options[:content_type] ||= 'application/json'
 
       headers = {

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -689,7 +689,7 @@ module DocusignRest
         enableWetSign:      options[:enable_wet_sign] || false,
         recipientsLock:     options[:recipients_lock] || false,
         customFields: options[:custom_fields]
-      }.to_json
+      }.merge(file_params).to_json
 
       uri = build_uri("/accounts/#{@acct_id}/envelopes/#{options[:envelope_id]}/documents")
 

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -676,7 +676,9 @@ module DocusignRest
         emailSubject: "#{options[:email][:subject] if options[:email]}",
         documents: get_documents(ios),
         eventNotification:  get_event_notification(options[:event_notification]),
-        recipients: {},
+        recipients: {
+          signers: get_signers(options[:signers])
+        },
         status: "#{options[:status]}",
         enableWetSign:      options[:enable_wet_sign] || false,
         recipientsLock:     options[:recipients_lock] || false,

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -676,9 +676,7 @@ module DocusignRest
         emailSubject: "#{options[:email][:subject] if options[:email]}",
         documents: get_documents(ios),
         eventNotification:  get_event_notification(options[:event_notification]),
-        recipients: {
-          signers: get_signers(options[:signers])
-        },
+        recipients: {},
         status: "#{options[:status]}",
         enableWetSign:      options[:enable_wet_sign] || false,
         recipientsLock:     options[:recipients_lock] || false,

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -698,7 +698,8 @@ module DocusignRest
       http = initialize_net_http_ssl(uri)
       
       request = Net::HTTP::Put.new(uri.request_uri, headers(headers))
-      request.body = post_body.merge(file_params),
+      request.body = post_body
+      request.merge(file_params),
       
       response = http.request(request)
       JSON.parse(response.body)

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -689,7 +689,9 @@ module DocusignRest
         enableWetSign:      options[:enable_wet_sign] || false,
         recipientsLock:     options[:recipients_lock] || false,
         customFields: options[:custom_fields]
-      }.merge(file_params).to_json
+      }.to_json
+      
+      post_body.merge(file_params)
 
       uri = build_uri("/accounts/#{@acct_id}/envelopes/#{options[:envelope_id]}/documents")
 

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -671,6 +671,14 @@ module DocusignRest
       ios = create_file_ios(options[:files])
       file_params = create_file_params(ios)
 
+      debugger
+
+      options[:content_type] ||= 'application/json'
+
+      headers = {
+        'Content-Type' => options[:content_type],
+      }
+
       post_body = {
         emailBlurb:   "#{options[:email][:body] if options[:email]}",
         emailSubject: "#{options[:email][:subject] if options[:email]}",
@@ -688,11 +696,10 @@ module DocusignRest
       uri = build_uri("/accounts/#{@acct_id}/envelopes/#{options[:envelope_id]}/documents")
 
       http = initialize_net_http_ssl(uri)
-
-      request = initialize_net_http_multipart_post_request(
-                  uri, post_body, file_params, headers(options[:headers])
-                )
-
+      
+      request = Net::HTTP::Put.new(uri.request_uri, headers(headers))
+      request.body = post_body.merge(file_params),
+      
       response = http.request(request)
       JSON.parse(response.body)
     end

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -699,7 +699,7 @@ module DocusignRest
       
       request = Net::HTTP::Put.new(uri.request_uri, headers(headers))
       request.body = post_body
-      request.merge(file_params),
+      request.merge(file_params)
       
       response = http.request(request)
       JSON.parse(response.body)

--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -699,7 +699,6 @@ module DocusignRest
       
       request = Net::HTTP::Put.new(uri.request_uri, headers(headers))
       request.body = post_body
-      request.merge(file_params)
       
       response = http.request(request)
       JSON.parse(response.body)


### PR DESCRIPTION
The high amount of commits is because I initially thought the only way to test changes was to push to github then update gem from that branch